### PR TITLE
[FEAT]조직도 메인 페이지

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,18 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { RouterProvider } from 'react-router-dom';
 
 import { router } from './route/router.tsx';
+
 import '@/styles/styles.css';
 
-function App() {
-  const queryClient = new QueryClient();
+const queryClient = new QueryClient();
 
+function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
+      <ReactQueryDevtools />
     </QueryClientProvider>
   );
 }

--- a/src/components/common/DropDown.tsx
+++ b/src/components/common/DropDown.tsx
@@ -1,13 +1,13 @@
-import { useRef, useState } from 'react';
+import { Key, useRef, useState } from 'react';
 
 import useOuterClick from '@/hooks/useOuterClick';
 
-export interface DropdownOption<T extends string> {
+export interface DropdownOption<T> {
   value: T;
   label: string;
 }
 
-interface DropdownProps<T extends string> {
+interface DropdownProps<T> {
   options: DropdownOption<T>[];
   value?: T;
   onChange?: (value: T) => void;
@@ -19,7 +19,7 @@ interface DropdownProps<T extends string> {
 
 /*아래는 미지정 시 기본값이며 이 컴포넌트 사용하실 때마다 디자인 맞춰서 바꿔주시면 됩니다!*/
 
-const Dropdown = <T extends string>({
+const Dropdown = <T extends Key>({
   options,
   value,
   onChange,

--- a/src/components/common/Loading.tsx
+++ b/src/components/common/Loading.tsx
@@ -1,0 +1,33 @@
+export const Loading = () => {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-white">
+      <svg
+        className="h-12 w-12 animate-spin text-pointColor"
+        viewBox="0 0 50 50"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="25"
+          cy="25"
+          r="20"
+          stroke="currentColor"
+          strokeWidth="4"
+          strokeDasharray="100"
+          strokeLinecap="round"
+          opacity="0.3"
+        />
+        <circle
+          cx="25"
+          cy="25"
+          r="20"
+          stroke="currentColor"
+          strokeWidth="4"
+          strokeDasharray="100"
+          strokeDashoffset="75"
+          strokeLinecap="round"
+        />
+      </svg>
+    </div>
+  );
+};

--- a/src/components/organization/CorporationSelect.tsx
+++ b/src/components/organization/CorporationSelect.tsx
@@ -1,10 +1,24 @@
-import GroupSelectBtn from './GroupSelectBtn';
+import Dropdown, { DropdownOption } from '../common/DropDown';
 
-const CorporationSelect = () => {
+type CorporationSelectProps = {
+  corpOptions: DropdownOption<number>[];
+  selectedCorp: number;
+  setSelectedCorp: (value: number) => void;
+};
+const CorporationSelect = ({
+  corpOptions,
+  selectedCorp,
+  setSelectedCorp,
+}: CorporationSelectProps) => {
   return (
     <div className="flex items-center gap-2.5 text-sm font-medium">
       <div>법인선택</div>
-      <GroupSelectBtn team="인프라보안팀" />
+      <Dropdown
+        options={corpOptions}
+        value={selectedCorp}
+        onChange={setSelectedCorp}
+        placeholder=""
+      />
     </div>
   );
 };

--- a/src/components/organization/GroupRow.tsx
+++ b/src/components/organization/GroupRow.tsx
@@ -8,25 +8,19 @@ import { useGetTeamDetail } from '@/usecases/organization';
 import { cn } from '@/utils/cn';
 
 const groupRowVariants = cva(
-  'whitespace-nowrap w-full flex h-9 items-center py-2.5 pr-2 gap-1 border-b border-solid border-borderGray text-sm font-medium text-black',
+  'whitespace-nowrap w-full flex h-9 items-center py-2.5 pr-2 gap-1 border-b border-solid border-borderGray text-sm font-medium text-black hover:bg-backgroundGray transition-all',
   {
     variants: {
       state: {
         default: 'bg-white ',
-        hover: 'bg-backgroundGray',
         hold: 'bg-[rgba(25,240,120,0.2)]',
         unselected: 'bg-backgroundUnselected',
         selected: 'text-backgroundGreen bg-backgroundSelected',
-      },
-      unclassified: {
-        true: 'text-textGray2',
-        false: '',
       },
     },
 
     defaultVariants: {
       state: 'default',
-      unclassified: false,
     },
   }
 );
@@ -34,43 +28,32 @@ const groupRowVariants = cva(
 interface GroupRowProps extends VariantProps<typeof groupRowVariants> {
   tId: number;
   level?: number;
-  state?: 'default' | 'hover' | 'hold' | 'unselected' | 'selected';
   isEdit?: boolean;
-  unclassified?: boolean;
   children?: GroupRowProps[];
+  selectedTId: number | null;
+  setSelectedTId: (tId: number) => void;
 }
-
 const GroupRow = ({
   tId,
   level = 1,
-  state = 'default',
   isEdit = false,
-  unclassified = false,
+  selectedTId,
+  setSelectedTId,
 }: GroupRowProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
+
   const hasUpperOrg = level > 1;
   const basePadding = 14;
   const paddingIncrement = 24;
-  const { teamDetail, isLoading, isError, isSuccess } = useGetTeamDetail(tId);
+  const { teamDetail, isTeamLoading, isError, isSuccess } =
+    useGetTeamDetail(tId);
+  const isSelected = selectedTId === tId;
+  const state = isSelected ? 'selected' : 'default';
+  const handleClick = () => {
+    setSelectedTId(tId);
+  };
 
-  console.log('teamDetail', teamDetail);
-  if (unclassified) {
-    return (
-      <div
-        className={cn(
-          groupRowVariants({
-            state,
-            unclassified: true,
-          })
-        )}
-        style={{ paddingLeft: `${basePadding}px` }}
-      >
-        <span className="flex-1">미분류 그룹</span>
-      </div>
-    );
-  }
-
-  if (!isSuccess) {
+  if (!isSuccess || isError || teamDetail === null) {
     return null;
   }
   const hasChildren = teamDetail.sub_teams.length > 0;
@@ -83,26 +66,22 @@ const GroupRow = ({
         className={cn(
           groupRowVariants({
             state,
-            unclassified,
           })
         )}
         style={{ paddingLeft: `${paddingValue}px` }}
+        onClick={handleClick}
       >
         {hasUpperOrg && <div className="pr-1">{Icons.Line}</div>}
 
         {hasChildren && (
           <button
             onClick={() => setIsExpanded(!isExpanded)}
-            className={cn('px-1 transition-transform', {
-              'rotate-180': isExpanded,
-            })}
+            className={cn('px-1 transition-transform')}
           >
             {isExpanded ? Icons.TriangleButtonOpen : Icons.TriangleButtonClose}
           </button>
         )}
-        <span className="flex-1">
-          {unclassified ? '미분류 그룹' : teamDetail.name}
-        </span>
+        <span className="flex-1">{teamDetail.name}</span>
         {isEdit && (
           <EditBtn
             onClick={() => {}}
@@ -111,12 +90,15 @@ const GroupRow = ({
         )}
       </div>
       {isExpanded &&
+        hasChildren &&
         teamDetail.sub_teams.map((sub_team) => (
           <GroupRow
             key={sub_team.t_id}
             tId={sub_team.t_id}
             level={level + 1}
             isEdit={isEdit}
+            selectedTId={selectedTId}
+            setSelectedTId={setSelectedTId}
           />
         ))}
     </>

--- a/src/components/organization/GroupRow.tsx
+++ b/src/components/organization/GroupRow.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import EditBtn from './EditBtn';
 
 import { Icons } from '@/constants/icons';
+import { useGetTeamDetail } from '@/usecases/organization';
 import { cn } from '@/utils/cn';
 
 const groupRowVariants = cva(
@@ -31,7 +32,7 @@ const groupRowVariants = cva(
 );
 
 interface GroupRowProps extends VariantProps<typeof groupRowVariants> {
-  name: string;
+  tId: number;
   level?: number;
   state?: 'default' | 'hover' | 'hold' | 'unselected' | 'selected';
   isEdit?: boolean;
@@ -40,18 +41,39 @@ interface GroupRowProps extends VariantProps<typeof groupRowVariants> {
 }
 
 const GroupRow = ({
-  name,
+  tId,
   level = 1,
   state = 'default',
   isEdit = false,
   unclassified = false,
-  children = [],
 }: GroupRowProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const hasUpperOrg = level > 1;
-  const hasChildren = children.length > 0;
   const basePadding = 14;
   const paddingIncrement = 24;
+  const { teamDetail, isLoading, isError, isSuccess } = useGetTeamDetail(tId);
+
+  console.log('teamDetail', teamDetail);
+  if (unclassified) {
+    return (
+      <div
+        className={cn(
+          groupRowVariants({
+            state,
+            unclassified: true,
+          })
+        )}
+        style={{ paddingLeft: `${basePadding}px` }}
+      >
+        <span className="flex-1">미분류 그룹</span>
+      </div>
+    );
+  }
+
+  if (!isSuccess) {
+    return null;
+  }
+  const hasChildren = teamDetail.sub_teams.length > 0;
   const paddingValue =
     !hasChildren && !hasUpperOrg ? basePadding : (level - 1) * paddingIncrement;
 
@@ -78,7 +100,9 @@ const GroupRow = ({
             {isExpanded ? Icons.TriangleButtonOpen : Icons.TriangleButtonClose}
           </button>
         )}
-        <span className="flex-1">{name}</span>
+        <span className="flex-1">
+          {unclassified ? '미분류 그룹' : teamDetail.name}
+        </span>
         {isEdit && (
           <EditBtn
             onClick={() => {}}
@@ -87,10 +111,10 @@ const GroupRow = ({
         )}
       </div>
       {isExpanded &&
-        children.map((child, index) => (
+        teamDetail.sub_teams.map((sub_team) => (
           <GroupRow
-            key={index}
-            {...child}
+            key={sub_team.t_id}
+            tId={sub_team.t_id}
             level={level + 1}
             isEdit={isEdit}
           />

--- a/src/components/organization/OrgDetail.tsx
+++ b/src/components/organization/OrgDetail.tsx
@@ -1,14 +1,21 @@
 import ListHeader from './ListHeader';
 import ListSpace from './LIstSpace';
 
-import { TeamDetail } from '@/entities/organization';
-
 type OrgDetailProps = {
-  teamDetail: TeamDetail;
+  detail: Detail;
 };
-
-const OrgDetail = ({ teamDetail }: OrgDetailProps) => {
-  console.log(teamDetail);
+type Detail = {
+  name: string;
+  member_count: number;
+  members: Member[];
+  corporation: { name: string };
+};
+type Member = {
+  p_id: number;
+  name: string;
+  roles: { role: string }[];
+};
+const OrgDetail = ({ detail }: OrgDetailProps) => {
   const listBackShadow =
     'shadow-inner shadow-[0px_0px_5px_0px_rgba(0,0,0,0.05)]';
   return (
@@ -16,16 +23,16 @@ const OrgDetail = ({ teamDetail }: OrgDetailProps) => {
       className={`${listBackShadow} flex h-[763px] flex-col rounded-md bg-backgroundGray`}
     >
       <ListHeader
-        title={teamDetail.name}
-        count={teamDetail.member_count}
+        title={detail.name}
+        count={detail.member_count}
       />
       <div className="m-[6px] flex flex-1 flex-col gap-1.5 overflow-y-auto">
-        {teamDetail?.members.map((member) => (
+        {detail?.members.map((member) => (
           <ListSpace
             key={member.p_id}
             name={member.name}
-            company={teamDetail.corporation.name}
-            department={teamDetail.name}
+            company={detail.corporation.name}
+            department={detail.name}
             position={member.roles.map((item) => item.role).join(', ')}
           />
         ))}

--- a/src/components/organization/OrgDetail.tsx
+++ b/src/components/organization/OrgDetail.tsx
@@ -1,9 +1,14 @@
 import ListHeader from './ListHeader';
 import ListSpace from './LIstSpace';
 
-import mockListSpaceData from '@/mocks/mockListSpaceData';
+import { TeamDetail } from '@/entities/organization';
 
-const OrgDetail = () => {
+type OrgDetailProps = {
+  teamDetail: TeamDetail;
+};
+
+const OrgDetail = ({ teamDetail }: OrgDetailProps) => {
+  console.log(teamDetail);
   const listBackShadow =
     'shadow-inner shadow-[0px_0px_5px_0px_rgba(0,0,0,0.05)]';
   return (
@@ -11,19 +16,17 @@ const OrgDetail = () => {
       className={`${listBackShadow} flex h-[763px] flex-col rounded-md bg-backgroundGray`}
     >
       <ListHeader
-        title="위메이드"
-        count={78}
+        title={teamDetail.name}
+        count={teamDetail.member_count}
       />
       <div className="m-[6px] flex flex-1 flex-col gap-1.5 overflow-y-auto">
-        {mockListSpaceData.map((item) => (
+        {teamDetail?.members.map((member) => (
           <ListSpace
-            key={item.id}
-            name={item.name}
-            company={item.company}
-            department={item.department}
-            position={item.position}
-            state={item.state as 'default' | 'select'}
-            isHovered={item.isHovered}
+            key={member.p_id}
+            name={member.name}
+            company={teamDetail.corporation.name}
+            department={teamDetail.name}
+            position={member.roles.map((item) => item.role).join(', ')}
           />
         ))}
       </div>

--- a/src/components/organization/OrgList.tsx
+++ b/src/components/organization/OrgList.tsx
@@ -1,18 +1,22 @@
 import GroupRow from './GroupRow';
+import UnclassifiedGroupRow from './UnclassifiedGroupRow';
 
 import { SubTeam } from '@/entities/organization';
 
 type OrgListProps = {
   teamList: team[];
+  selectedTId: number | null;
+  setSelectedTId: (tId: number) => void;
 };
 type team = {
   tId: number;
   name: string;
   sub_teams: SubTeam[];
 };
-const OrgList = ({ teamList }: OrgListProps) => {
+const OrgList = ({ teamList, selectedTId, setSelectedTId }: OrgListProps) => {
   const listBackShadow =
     'shadow-inner shadow-[0px_0px_5px_0px_rgba(0,0,0,0.05)]';
+
   return (
     <div className={`${listBackShadow} h-[763px] rounded-md bg-backgroundGray`}>
       <div className="m-[6px] flex h-[709px] max-h-[709px] flex-col overflow-x-auto rounded-sm border border-textGray1 bg-white">
@@ -22,15 +26,14 @@ const OrgList = ({ teamList }: OrgListProps) => {
               tId={team.tId}
               level={team.sub_teams.length > 0 ? 1 : 0}
               key={team.tId}
+              selectedTId={selectedTId}
+              setSelectedTId={setSelectedTId}
             />
           ))}
         </div>
       </div>
       <div className="m-[6px] flex h-9 rounded-sm border border-textGray1 bg-white">
-        <GroupRow
-          tId={0}
-          unclassified={true}
-        />
+        <UnclassifiedGroupRow />
       </div>
     </div>
   );

--- a/src/components/organization/OrgList.tsx
+++ b/src/components/organization/OrgList.tsx
@@ -33,7 +33,10 @@ const OrgList = ({ teamList, selectedTId, setSelectedTId }: OrgListProps) => {
         </div>
       </div>
       <div className="m-[6px] flex h-9 rounded-sm border border-textGray1 bg-white">
-        <UnclassifiedGroupRow />
+        <UnclassifiedGroupRow
+          selectedTId={selectedTId}
+          setSelectedTId={setSelectedTId}
+        />
       </div>
     </div>
   );

--- a/src/components/organization/OrgList.tsx
+++ b/src/components/organization/OrgList.tsx
@@ -1,8 +1,6 @@
 import GroupRow from './GroupRow';
 import UnclassifiedGroupRow from './UnclassifiedGroupRow';
 
-import { SubTeam } from '@/entities/organization';
-
 type OrgListProps = {
   teamList: team[];
   selectedTId: number | null;

--- a/src/components/organization/OrgList.tsx
+++ b/src/components/organization/OrgList.tsx
@@ -11,7 +11,7 @@ type OrgListProps = {
 type team = {
   tId: number;
   name: string;
-  sub_teams: SubTeam[];
+  sub_team_count: number;
 };
 const OrgList = ({ teamList, selectedTId, setSelectedTId }: OrgListProps) => {
   const listBackShadow =
@@ -24,7 +24,7 @@ const OrgList = ({ teamList, selectedTId, setSelectedTId }: OrgListProps) => {
           {teamList.map((team) => (
             <GroupRow
               tId={team.tId}
-              level={team.sub_teams.length > 0 ? 1 : 0}
+              level={team.sub_team_count > 0 ? 1 : 0}
               key={team.tId}
               selectedTId={selectedTId}
               setSelectedTId={setSelectedTId}

--- a/src/components/organization/OrgList.tsx
+++ b/src/components/organization/OrgList.tsx
@@ -1,25 +1,34 @@
 import GroupRow from './GroupRow';
 
-import mockGroupRows from '@/mocks/mockGroupRows';
+import { SubTeam } from '@/entities/organization';
 
-const OrgList = () => {
+type OrgListProps = {
+  teamList: team[];
+};
+type team = {
+  tId: number;
+  name: string;
+  sub_teams: SubTeam[];
+};
+const OrgList = ({ teamList }: OrgListProps) => {
   const listBackShadow =
     'shadow-inner shadow-[0px_0px_5px_0px_rgba(0,0,0,0.05)]';
   return (
     <div className={`${listBackShadow} h-[763px] rounded-md bg-backgroundGray`}>
       <div className="m-[6px] flex h-[709px] max-h-[709px] flex-col overflow-x-auto rounded-sm border border-textGray1 bg-white">
         <div className="w-max min-w-full">
-          {mockGroupRows.map((group, index) => (
+          {teamList.map((team) => (
             <GroupRow
-              key={index}
-              {...group}
+              tId={team.tId}
+              level={team.sub_teams.length > 0 ? 1 : 0}
+              key={team.tId}
             />
           ))}
         </div>
       </div>
       <div className="m-[6px] flex h-9 rounded-sm border border-textGray1 bg-white">
         <GroupRow
-          name="미분류 그룹"
+          tId={0}
           unclassified={true}
         />
       </div>

--- a/src/components/organization/SortOrder.tsx
+++ b/src/components/organization/SortOrder.tsx
@@ -11,15 +11,15 @@ const SortOrder = ({ onSelect, selectedValue, options }: SortOrderProps) => {
 
   return (
     <div className="relative inline-block">
-      <button
+      <div
         className={cn(
-          'flex h-8 w-[100px] items-center justify-center rounded-md border border-solid border-textGreen bg-white px-3 py-1 text-sm font-medium text-black transition-all hover:bg-backgroundGray',
+          'flex h-8 w-[100px] items-center justify-center rounded-md border border-solid border-textGreen bg-white px-3 py-1 text-sm font-medium text-black transition-all',
           isOpen && 'bg-backgroundGray'
         )}
-        onClick={() => setIsOpen(!isOpen)}
+        // onClick={() => setIsOpen(!isOpen)}
       >
         {selectedValue}
-      </button>
+      </div>
 
       {isOpen && (
         <div className="absolute left-0 mt-1 rounded-md border border-solid border-textGreen bg-white text-sm font-medium text-black shadow-md">

--- a/src/components/organization/SortOrder.tsx
+++ b/src/components/organization/SortOrder.tsx
@@ -13,11 +13,10 @@ const SortOrder = ({ onSelect, selectedValue, options }: SortOrderProps) => {
     <div className="relative inline-block">
       <button
         className={cn(
-          'flex h-8 w-[100px] items-center justify-center rounded-md border border-solid border-textGreen bg-white px-3 py-1 text-sm font-medium text-black transition-all',
+          'flex h-8 w-[100px] items-center justify-center rounded-md border border-solid border-textGreen bg-white px-3 py-1 text-sm font-medium text-black transition-all hover:bg-backgroundGray',
           isOpen && 'bg-backgroundGray'
         )}
         onClick={() => setIsOpen(!isOpen)}
-        onMouseEnter={() => !isOpen && setIsOpen(true)}
       >
         {selectedValue}
       </button>

--- a/src/components/organization/UnclassifiedGroupRow.tsx
+++ b/src/components/organization/UnclassifiedGroupRow.tsx
@@ -1,0 +1,57 @@
+import { cva, VariantProps } from 'class-variance-authority';
+
+import EditBtn from './EditBtn';
+
+import { cn } from '@/utils/cn';
+
+const unclassifiedGroupRowVariants = cva(
+  'whitespace-nowrap w-full flex h-9 items-center py-2.5 pr-2 pl-3.5 gap-1 border-b border-solid border-borderGray text-sm font-medium  hover:bg-backgroundGray transition-all text-textGray2',
+  {
+    variants: {
+      state: {
+        default: 'bg-white ',
+        hold: 'bg-[rgba(25,240,120,0.2)]',
+        unselected: 'bg-backgroundUnselected',
+        selected: 'text-backgroundGreen bg-backgroundSelected',
+      },
+    },
+
+    defaultVariants: {
+      state: 'default',
+    },
+  }
+);
+
+interface UnclassifiedGroupRowProps
+  extends VariantProps<typeof unclassifiedGroupRowVariants> {
+  isEdit?: boolean;
+}
+const UnclassifiedGroupRow = ({
+  isEdit = false,
+}: UnclassifiedGroupRowProps) => {
+  const state = 'default';
+  const handleClick = () => {};
+
+  return (
+    <>
+      <div
+        className={cn(
+          unclassifiedGroupRowVariants({
+            state,
+          })
+        )}
+        onClick={handleClick}
+      >
+        <span className="flex-1">미분류 그룹</span>
+        {isEdit && (
+          <EditBtn
+            onClick={() => {}}
+            text="수정됨"
+          />
+        )}
+      </div>
+    </>
+  );
+};
+
+export default UnclassifiedGroupRow;

--- a/src/components/organization/UnclassifiedGroupRow.tsx
+++ b/src/components/organization/UnclassifiedGroupRow.tsx
@@ -25,12 +25,18 @@ const unclassifiedGroupRowVariants = cva(
 interface UnclassifiedGroupRowProps
   extends VariantProps<typeof unclassifiedGroupRowVariants> {
   isEdit?: boolean;
+  selectedTId: number | null;
+  setSelectedTId: (tId: number) => void;
 }
 const UnclassifiedGroupRow = ({
   isEdit = false,
+  setSelectedTId,
+  selectedTId,
 }: UnclassifiedGroupRowProps) => {
-  const state = 'default';
-  const handleClick = () => {};
+  const state = selectedTId == -1 ? 'selected' : 'default';
+  const handleClick = () => {
+    setSelectedTId(-1);
+  };
 
   return (
     <>

--- a/src/entities/organization.ts
+++ b/src/entities/organization.ts
@@ -48,3 +48,13 @@ export type Role = {
   r_id: number;
   role: string; // 부서장, 팀원
 };
+
+export type UnclassifiedPerson = {
+  p_id: number;
+  name: string;
+  emails: string[];
+  phone_number: string;
+  corporations: number[]; // c_id
+  teams: number[]; // t_id
+  roles: Role[];
+};

--- a/src/entities/organization.ts
+++ b/src/entities/organization.ts
@@ -1,0 +1,7 @@
+export type Corp = {
+  c_id: number;
+  name: string;
+  sub_teams: number[];
+  is_active: boolean;
+  is_master: boolean;
+};

--- a/src/entities/organization.ts
+++ b/src/entities/organization.ts
@@ -5,3 +5,46 @@ export type Corp = {
   is_active: boolean;
   is_master: boolean;
 };
+
+export type CorpDetail = {
+  c_id: number;
+  name: string;
+  sub_teams: number[]; // t_id
+  hr_team: number;
+  is_active: boolean;
+};
+
+export type TeamDetail = {
+  t_id: number;
+  name: string;
+  corporation: CorpDetail;
+  sub_teams: SubTeam[];
+  parent_teams: number[];
+  team_leader: number;
+  members: Member[];
+  member_count: number;
+  is_active: boolean;
+  created_at: string;
+  deleted_at: string | null;
+};
+export type SubTeam = {
+  corporation: number; // c_id
+  is_active: boolean;
+  name: string;
+  t_id: number;
+};
+export type Member = {
+  p_id: number;
+  name: string;
+  emails: string[];
+  phone_number: string;
+  corporations: number[]; // c_id
+  teams: number[]; // t_id
+  roles: Role[];
+};
+
+export type Role = {
+  t_id: number;
+  r_id: number;
+  role: string; // 부서장, 팀원
+};

--- a/src/entities/organization.ts
+++ b/src/entities/organization.ts
@@ -58,3 +58,11 @@ export type UnclassifiedPerson = {
   teams: number[]; // t_id
   roles: Role[];
 };
+
+export type SearchTeam = {
+  t_id: number;
+  name: string;
+  corporation: number; // c_id
+  sub_teams: number[];
+  is_active: boolean;
+};

--- a/src/pages/OAuthCallback.tsx
+++ b/src/pages/OAuthCallback.tsx
@@ -20,7 +20,7 @@ const OAuthCallback = () => {
 
   const { data, isLoading } = useGetRequestWithoutToken<AuthResponse>(
     ['google-code'],
-    `/api/v1/auth/google/callback?code=${code}&profile=${import.meta.env.VITE_PROFILE}`,
+    `/auth/google/callback?code=${code}&profile=${import.meta.env.VITE_PROFILE}`,
     {
       refetchOnWindowFocus: true,
     }
@@ -68,7 +68,7 @@ const OAuthCallback = () => {
     setAccessToken(data.access_token);
     localStorage.setItem('accessToken', data.access_token);
     localStorage.setItem('refreshToken', data.refresh_token);
-    navigate('/auth/signup');
+    navigate('/org');
   }
 
   return null;

--- a/src/pages/Organization.tsx
+++ b/src/pages/Organization.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { Loading } from '@/components/common/Loading';
 import SearchBar from '@/components/common/SearchBar';
@@ -15,7 +16,9 @@ import {
 } from '@/usecases/organization';
 
 const Organization = () => {
-  const [selectedSort, setSelectedSort] = useState('가나다순');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const selectedSort = searchParams.get('sort') ?? '가나다순';
 
   const { corpOptions, isLoading: isLoadingOptions } = useGetCorporateOptions();
   const [selectedCorp, setSelectedCorp] = useState<number>(1);
@@ -27,6 +30,11 @@ const Organization = () => {
     return <Loading />;
   }
 
+  const handleSelectedSort = (newSort: string) => {
+    const params = new URLSearchParams(searchParams);
+    params.set('sort', newSort);
+    setSearchParams(params, { replace: true });
+  };
   return (
     <div className="flex flex-col gap-5">
       <div className="flex items-center justify-between">
@@ -53,7 +61,7 @@ const Organization = () => {
           <div className="flex justify-end">
             <SortOrder
               selectedValue={selectedSort}
-              onSelect={setSelectedSort}
+              onSelect={handleSelectedSort}
               options={['가나다순', '직급순']}
             />
           </div>

--- a/src/pages/Organization.tsx
+++ b/src/pages/Organization.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 
 import { Loading } from '@/components/common/Loading';
 import SearchBar from '@/components/common/SearchBar';
@@ -13,11 +13,11 @@ import {
   useGetCorporateOptions,
   useGetTeamDetail,
   useGetTeamListInCorp,
+  useGetUnclassifiedGroup,
 } from '@/usecases/organization';
 
 const Organization = () => {
   const [searchParams, setSearchParams] = useSearchParams();
-  const navigate = useNavigate();
   const selectedSort = searchParams.get('sort') ?? '가나다순';
 
   const { corpOptions, isLoading: isLoadingOptions } = useGetCorporateOptions();
@@ -25,8 +25,12 @@ const Organization = () => {
   const { teamList, isLoading } = useGetTeamListInCorp(selectedCorp);
   const [selectedTId, setSelectedTId] = useState<number | null>(null);
 
-  const { teamDetail, isTeamLoading } = useGetTeamDetail(selectedTId ?? 1);
-  if (isLoadingOptions || isLoading || isTeamLoading) {
+  const { teamDetail, isTeamLoading } = useGetTeamDetail(
+    selectedTId === null || selectedTId === -1 ? 1 : selectedTId
+  );
+  const { unclassifiedGroup, isUnclassifiedLoading } =
+    useGetUnclassifiedGroup();
+  if (isLoadingOptions || isLoading || isTeamLoading || isUnclassifiedLoading) {
     return <Loading />;
   }
 
@@ -65,7 +69,23 @@ const Organization = () => {
               options={['가나다순', '직급순']}
             />
           </div>
-          {teamDetail && <OrgDetail teamDetail={teamDetail} />}
+          {(selectedTId ?? -1) !== -1 && teamDetail && (
+            <OrgDetail detail={teamDetail} />
+          )}
+          {selectedTId === -1 && unclassifiedGroup && (
+            <OrgDetail
+              detail={{
+                name: '미분류그룹',
+                member_count: unclassifiedGroup.length,
+                members: unclassifiedGroup,
+                corporation: {
+                  name:
+                    corpOptions.find((corp) => corp.value === selectedCorp)
+                      ?.label ?? '',
+                },
+              }}
+            />
+          )}
         </div>
       </div>
       <GroupMenu />

--- a/src/pages/Organization.tsx
+++ b/src/pages/Organization.tsx
@@ -14,15 +14,25 @@ import {
   useGetTeamDetail,
   useGetTeamListInCorp,
   useGetUnclassifiedGroup,
+  useSearchTeam,
 } from '@/usecases/organization';
 
 const Organization = () => {
+  const [inputText, setInputText] = useState('');
+  const [searchText, setSearchText] = useState('');
+
   const [searchParams, setSearchParams] = useSearchParams();
   const selectedSort = searchParams.get('sort') ?? '가나다순';
 
   const { corpOptions, isLoading: isLoadingOptions } = useGetCorporateOptions();
   const [selectedCorp, setSelectedCorp] = useState<number>(1);
-  const { teamList, isLoading } = useGetTeamListInCorp(selectedCorp);
+  const { teamList: defaultTeamList, isLoading } =
+    useGetTeamListInCorp(selectedCorp);
+  const { teamList: searchedTeamList, isSearchLoading } = useSearchTeam(
+    searchText,
+    selectedCorp
+  );
+
   const [selectedTId, setSelectedTId] = useState<number | null>(null);
 
   const { teamDetail, isTeamLoading } = useGetTeamDetail(
@@ -30,7 +40,13 @@ const Organization = () => {
   );
   const { unclassifiedGroup, isUnclassifiedLoading } =
     useGetUnclassifiedGroup();
-  if (isLoadingOptions || isLoading || isTeamLoading || isUnclassifiedLoading) {
+  if (
+    isLoadingOptions ||
+    isLoading ||
+    isTeamLoading ||
+    isUnclassifiedLoading ||
+    isSearchLoading
+  ) {
     return <Loading />;
   }
 
@@ -38,6 +54,13 @@ const Organization = () => {
     const params = new URLSearchParams(searchParams);
     params.set('sort', newSort);
     setSearchParams(params, { replace: true });
+  };
+  const teamListToShow = searchText ? searchedTeamList : defaultTeamList;
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      setSearchText(inputText.trim());
+    }
   };
   return (
     <div className="flex flex-col gap-5">
@@ -54,9 +77,12 @@ const Organization = () => {
           <SearchBar
             placeholder="여기에서 부서명을 검색하세요."
             className="mt-4 text-[15px] font-medium"
+            value={inputText}
+            onChange={(e) => setInputText(e.target.value)}
+            onKeyDown={handleKeyDown}
           />
           <OrgList
-            teamList={teamList}
+            teamList={teamListToShow}
             selectedTId={selectedTId}
             setSelectedTId={setSelectedTId}
           />

--- a/src/pages/Organization.tsx
+++ b/src/pages/Organization.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { Loading } from '@/components/common/Loading';
 import SearchBar from '@/components/common/SearchBar';
 import CorporationSelect from '@/components/organization/CorporationSelect';
 import GroupMenu from '@/components/organization/GroupMenu';
@@ -9,16 +10,21 @@ import SortOrder from '@/components/organization/SortOrder';
 import { Icons } from '@/constants/icons';
 import {
   useGetCorporateOptions,
+  useGetTeamDetail,
   useGetTeamListInCorp,
 } from '@/usecases/organization';
 
 const Organization = () => {
   const [selectedSort, setSelectedSort] = useState('가나다순');
+
   const { corpOptions, isLoading: isLoadingOptions } = useGetCorporateOptions();
   const [selectedCorp, setSelectedCorp] = useState<number>(1);
-  const { teamList, isLoading, isError } = useGetTeamListInCorp(selectedCorp);
-  if (isLoadingOptions || isLoading) {
-    return <div>로딩중...</div>;
+  const { teamList, isLoading } = useGetTeamListInCorp(selectedCorp);
+  const [selectedTId, setSelectedTId] = useState<number | null>(null);
+
+  const { teamDetail, isTeamLoading } = useGetTeamDetail(selectedTId ?? 1);
+  if (isLoadingOptions || isLoading || isTeamLoading) {
+    return <Loading />;
   }
 
   return (
@@ -37,7 +43,11 @@ const Organization = () => {
             placeholder="여기에서 부서명을 검색하세요."
             className="mt-4 text-[15px] font-medium"
           />
-          <OrgList teamList={teamList} />
+          <OrgList
+            teamList={teamList}
+            selectedTId={selectedTId}
+            setSelectedTId={setSelectedTId}
+          />
         </div>
         <div className="RightSide mt-4 flex w-[445px] flex-col gap-[14px]">
           <div className="flex justify-end">
@@ -47,7 +57,7 @@ const Organization = () => {
               options={['가나다순', '직급순']}
             />
           </div>
-          <OrgDetail />
+          {teamDetail && <OrgDetail teamDetail={teamDetail} />}
         </div>
       </div>
       <GroupMenu />

--- a/src/pages/Organization.tsx
+++ b/src/pages/Organization.tsx
@@ -7,14 +7,22 @@ import OrgDetail from '@/components/organization/OrgDetail';
 import OrgList from '@/components/organization/OrgList';
 import SortOrder from '@/components/organization/SortOrder';
 import { Icons } from '@/constants/icons';
+import { useGetCorporateOptions } from '@/usecases/organization';
 
 const Organization = () => {
   const [selectedSort, setSelectedSort] = useState('가나다순');
+  const { corpOptions, isLoading } = useGetCorporateOptions();
+  const [selectedCorp, setSelectedCorp] = useState<number>(1);
+
   return (
     <div className="flex flex-col gap-5">
       <div className="flex items-center justify-between">
         <div>{Icons.OrgTitle}</div>
-        <CorporationSelect />
+        <CorporationSelect
+          corpOptions={corpOptions}
+          selectedCorp={selectedCorp}
+          setSelectedCorp={setSelectedCorp}
+        />
       </div>
       <div className="flex gap-5">
         <div className="flex w-[445px] flex-col gap-[14px]">

--- a/src/pages/Organization.tsx
+++ b/src/pages/Organization.tsx
@@ -7,12 +7,19 @@ import OrgDetail from '@/components/organization/OrgDetail';
 import OrgList from '@/components/organization/OrgList';
 import SortOrder from '@/components/organization/SortOrder';
 import { Icons } from '@/constants/icons';
-import { useGetCorporateOptions } from '@/usecases/organization';
+import {
+  useGetCorporateOptions,
+  useGetTeamListInCorp,
+} from '@/usecases/organization';
 
 const Organization = () => {
   const [selectedSort, setSelectedSort] = useState('가나다순');
-  const { corpOptions, isLoading } = useGetCorporateOptions();
+  const { corpOptions, isLoading: isLoadingOptions } = useGetCorporateOptions();
   const [selectedCorp, setSelectedCorp] = useState<number>(1);
+  const { teamList, isLoading, isError } = useGetTeamListInCorp(selectedCorp);
+  if (isLoadingOptions || isLoading) {
+    return <div>로딩중...</div>;
+  }
 
   return (
     <div className="flex flex-col gap-5">
@@ -30,7 +37,7 @@ const Organization = () => {
             placeholder="여기에서 부서명을 검색하세요."
             className="mt-4 text-[15px] font-medium"
           />
-          <OrgList />
+          <OrgList teamList={teamList} />
         </div>
         <div className="RightSide mt-4 flex w-[445px] flex-col gap-[14px]">
           <div className="flex justify-end">

--- a/src/route/router.tsx
+++ b/src/route/router.tsx
@@ -34,7 +34,7 @@ export const router = createBrowserRouter([
     ],
   },
   {
-    path: '/organization',
+    path: '/org',
     element: <OrgLayout />,
     children: [{ index: true, element: <Organization /> }],
   },

--- a/src/usecases/organization.ts
+++ b/src/usecases/organization.ts
@@ -40,25 +40,41 @@ export const useGetTeamListInCorp = (cId: number) => {
       sub_teams: team.data.sub_teams,
     }));
 
-  return { teamList: formattedTeamList, isLoading, isError };
+  return {
+    teamList: formattedTeamList,
+    isLoading,
+    isError,
+  };
 };
 
 export const useGetTeamDetail = (tId: number) => {
+  if (tId === 0) {
+    return {
+      teamDetail: null,
+      isSuccess: true,
+      isTeamLoading: false,
+      isError: false,
+    };
+  }
   const {
     data: teamDetail,
     isSuccess,
-    isLoading,
+    isLoading: isTeamLoading,
     isError,
   } = useGetRequest<TeamDetail>(['team', tId], `/company/team/${tId}`);
 
   if (isSuccess) {
     return {
       teamDetail,
-      isLoading,
-      isError,
       isSuccess,
+      isTeamLoading,
+      isError,
     };
   }
-  console.log('teamDetail', teamDetail);
-  return { teamDetail, isLoading, isError, isSuccess };
+  return {
+    teamDetail,
+    isSuccess,
+    isTeamLoading,
+    isError,
+  };
 };

--- a/src/usecases/organization.ts
+++ b/src/usecases/organization.ts
@@ -1,0 +1,17 @@
+import { Corp } from '@/entities/organization';
+import { useGetRequest } from '@/utils/api';
+import { useQueryClient } from '@tanstack/react-query';
+
+export const useGetCorporateOptions = () => {
+  const { data: corpList, isLoading } = useGetRequest<Corp[]>(
+    ['corporation'],
+    '/company/corp/list'
+  );
+
+  const corpOptions = (corpList ?? []).map((corp) => ({
+    value: corp.c_id,
+    label: corp.name,
+  }));
+
+  return { corpOptions, isLoading };
+};

--- a/src/usecases/organization.ts
+++ b/src/usecases/organization.ts
@@ -1,4 +1,9 @@
-import { Corp, CorpDetail, TeamDetail } from '@/entities/organization';
+import {
+  Corp,
+  CorpDetail,
+  TeamDetail,
+  UnclassifiedPerson,
+} from '@/entities/organization';
 import { useGetRequest, useGetRequests } from '@/utils/api';
 
 export const useGetCorporateOptions = () => {
@@ -48,14 +53,6 @@ export const useGetTeamListInCorp = (cId: number) => {
 };
 
 export const useGetTeamDetail = (tId: number) => {
-  if (tId === 0) {
-    return {
-      teamDetail: null,
-      isSuccess: true,
-      isTeamLoading: false,
-      isError: false,
-    };
-  }
   const {
     data: teamDetail,
     isSuccess,
@@ -77,4 +74,12 @@ export const useGetTeamDetail = (tId: number) => {
     isTeamLoading,
     isError,
   };
+};
+
+export const useGetUnclassifiedGroup = () => {
+  const { data, isLoading: isUnclassifiedLoading } = useGetRequest<
+    UnclassifiedPerson[]
+  >(['corporation', 'unclassified'], '/company/unclassified/list');
+
+  return { unclassifiedGroup: data, isUnclassifiedLoading };
 };

--- a/src/usecases/organization.ts
+++ b/src/usecases/organization.ts
@@ -1,6 +1,7 @@
 import {
   Corp,
   CorpDetail,
+  SearchTeam,
   TeamDetail,
   UnclassifiedPerson,
 } from '@/entities/organization';
@@ -43,6 +44,7 @@ export const useGetTeamListInCorp = (cId: number) => {
       tId: team.data.t_id,
       name: team.data.name,
       sub_teams: team.data.sub_teams,
+      sub_team_count: team.data.sub_teams.length,
     }));
 
   return {
@@ -82,4 +84,24 @@ export const useGetUnclassifiedGroup = () => {
   >(['corporation', 'unclassified'], '/company/unclassified/list');
 
   return { unclassifiedGroup: data, isUnclassifiedLoading };
+};
+
+export const useSearchTeam = (searchText: string, selectedCorp: number) => {
+  const { data, isLoading: isSearchLoading } = useGetRequest<SearchTeam[]>(
+    ['team', 'search', searchText],
+    `/search/team?q=${searchText}`
+  );
+  if (!data) {
+    return { teamList: [], isSearchLoading };
+  }
+  const teamList = data
+    .filter((team) => team.corporation === selectedCorp)
+    .map((team) => ({
+      tId: team.t_id,
+      name: team.name,
+      sub_teams: team.sub_teams,
+      sub_team_count: team.sub_teams.length,
+    }));
+
+  return { teamList, isSearchLoading };
 };

--- a/src/usecases/organization.ts
+++ b/src/usecases/organization.ts
@@ -1,10 +1,9 @@
-import { Corp } from '@/entities/organization';
-import { useGetRequest } from '@/utils/api';
-import { useQueryClient } from '@tanstack/react-query';
+import { Corp, CorpDetail, TeamDetail } from '@/entities/organization';
+import { useGetRequest, useGetRequests } from '@/utils/api';
 
 export const useGetCorporateOptions = () => {
   const { data: corpList, isLoading } = useGetRequest<Corp[]>(
-    ['corporation'],
+    ['corporations'],
     '/company/corp/list'
   );
 
@@ -14,4 +13,52 @@ export const useGetCorporateOptions = () => {
   }));
 
   return { corpOptions, isLoading };
+};
+
+export const useGetTeamListInCorp = (cId: number) => {
+  const {
+    data: corpDetail,
+    isLoading: corpLoading,
+    isError: corpError,
+  } = useGetRequest<CorpDetail>(['corporation', cId], `/company/corp/${cId}`);
+  const teamList = useGetRequests<TeamDetail>(
+    corpDetail?.sub_teams.map((tId) => ({
+      queryKey: ['team', tId],
+      endpoint: `/company/team/${tId}`,
+    })) ?? []
+  );
+
+  const isLoading = corpLoading || teamList.some((query) => query.isLoading);
+  const isError = corpError || teamList.some((query) => query.isError);
+
+  //id, name, sub_teams 식으로 가공
+  const formattedTeamList = teamList
+    .filter((team) => team.isSuccess)
+    .map((team) => ({
+      tId: team.data.t_id,
+      name: team.data.name,
+      sub_teams: team.data.sub_teams,
+    }));
+
+  return { teamList: formattedTeamList, isLoading, isError };
+};
+
+export const useGetTeamDetail = (tId: number) => {
+  const {
+    data: teamDetail,
+    isSuccess,
+    isLoading,
+    isError,
+  } = useGetRequest<TeamDetail>(['team', tId], `/company/team/${tId}`);
+
+  if (isSuccess) {
+    return {
+      teamDetail,
+      isLoading,
+      isError,
+      isSuccess,
+    };
+  }
+  console.log('teamDetail', teamDetail);
+  return { teamDetail, isLoading, isError, isSuccess };
 };

--- a/src/usecases/organization.ts
+++ b/src/usecases/organization.ts
@@ -89,7 +89,7 @@ export const useGetUnclassifiedGroup = () => {
 export const useSearchTeam = (searchText: string, selectedCorp: number) => {
   const { data, isLoading: isSearchLoading } = useGetRequest<SearchTeam[]>(
     ['team', 'search', searchText],
-    `/search/team?q=${searchText}`
+    `/search/team?${new URLSearchParams({ q: searchText })}`
   );
   if (!data) {
     return { teamList: [], isSearchLoading };

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -3,6 +3,8 @@ import {
   useMutation,
   UseQueryOptions,
   UseMutationOptions,
+  QueryKey,
+  useQueries,
 } from '@tanstack/react-query';
 import { useToken } from '@/hooks/useToken';
 
@@ -70,7 +72,7 @@ const fetchDataWithoutToken = async <T>({
 };
 // GET request
 export const useGetRequest = <T>(
-  queryKey: string[],
+  queryKey: QueryKey,
   endpoint: string,
   options?: Omit<UseQueryOptions<T>, 'queryKey'>
 ) => {
@@ -83,8 +85,27 @@ export const useGetRequest = <T>(
   });
 };
 
+export const useGetRequests = <T>(
+  queries: {
+    queryKey: QueryKey;
+    endpoint: string;
+    options?: Omit<UseQueryOptions<T>, 'queryKey'>;
+  }[]
+) => {
+  const { accessToken, clearTokens } = useToken();
+  const results = useQueries({
+    queries: queries.map(({ queryKey, endpoint, options }) => ({
+      queryKey,
+      queryFn: () =>
+        fetchData<T>({ endpoint, method: 'GET', accessToken, clearTokens }),
+      ...options,
+    })),
+  });
+  return results;
+};
+
 export const useGetRequestWithoutToken = <T>(
-  queryKey: string[],
+  queryKey: QueryKey,
   endpoint: string,
   options?: Omit<UseQueryOptions<T>, 'queryKey'>
 ) => {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -28,7 +28,6 @@ export const fetchData = async <T>({
   clearTokens,
 }: FetchOptions) => {
   const url = `${API_DOMAIN}${endpoint}`;
-  console.log('url', url);
   const response = await fetch(url, {
     method,
     headers: {


### PR DESCRIPTION
## 📝 작업 내용


<img width="184" alt="Screenshot 2025-03-12 at 2 40 04 PM" src="https://github.com/user-attachments/assets/7a2cc646-d87c-49ca-9ee5-7ed1dc86452f" />

* 법인선택에서 위메이드 모든 법인을 불러옵니다. 
<hr/>

<img width="462" alt="Screenshot 2025-03-12 at 3 03 00 PM" src="https://github.com/user-attachments/assets/cd1300cc-5ae9-427a-b5ef-652c9dbc52c2" />

* 법인선택에서 고른 법인에따라 팀이 불러와지고 여기서 api상 직속하위팀만 알 수 있기때문에 GroupRow 안에서 useGetTeamDetail으로 팀을 재귀함수로 불를는 식으로 작성했습니다.
<hr/>

<img width="927" alt="Screenshot 2025-03-12 at 2 46 55 PM" src="https://github.com/user-attachments/assets/17c59988-192a-473a-8dbb-f7025f6c8fee" />

* 이렇게 해당팀 클릭시 팀원 보여주는걸로 구현했습니다. 미 클릭시 지금 비어있는걸로 하고 있습니다.
* 미분류그룹도 법인선택으로 고른 회사안에 있는 구성원보여주는걸로 구현했습니다.
<hr/>

<img width="470" alt="Screenshot 2025-03-12 at 2 56 34 PM" src="https://github.com/user-attachments/assets/144171c5-e24b-4eab-8f28-18f7a4a613fd" />

* 그리고 SortOrder 같은 경우엔 일단 가나다순 만 보여주는걸로 해놨습니다. 추후에 필요하면 추가 하는걸로 할게요.
<hr/>
<img width="482" alt="Screenshot 2025-03-12 at 3 04 27 PM" src="https://github.com/user-attachments/assets/25d2c333-e027-4bcf-b711-5e0fa7c58d3f" />

* 팀검색같은 경우 지금은 키워드 입력하고 엔터칠땐 해당 법인안에 결과 있으면 뜨고 아니면 안 보이는걸로 되어있습니다.

## TODO
* 로딩처리 및 애러처리 개선이 필요한 것  같아 리팩토링 다시 할 계획입니다.